### PR TITLE
Fix/search regression

### DIFF
--- a/parts/parts.go
+++ b/parts/parts.go
@@ -52,7 +52,7 @@ func makeTOC(tree []fs.Entity) string {
 			list = append(list, fmt.Sprintf(`<details id="anchor-%s"><summary>%s</summary><div class="sidebar-group-wrapper">%s</div></details>`, v.CompoundID(), v.Meta().Title, makeTOC(v.Children)))
 		case *fs.Section:
 			compID := v.CompoundID()
-			list = append(list, fmt.Sprintf(`<a href="#content-%s" id="anchor-%s">%s</a>`, compID, compID, v.Meta().Title))
+			list = append(list, fmt.Sprintf(`<a href="#%s" id="anchor-%s">%s</a>`, compID, compID, v.Meta().Title))
 		}
 	}
 

--- a/parts/section.html
+++ b/parts/section.html
@@ -1,12 +1,12 @@
 {{ if eq .ID "" }}
 <section class="section">
 {{ else }}
-<section class="section">
+<section class="section" id="content-{{.ID}}">
 {{ end }}
   <div class="section-wrapper">
     <div class="content">
       {{ if .HasTitle }}
-        <h1><span class="anchor-ref" id="content-{{.ID}}"></span>{{.Title}}</h1>
+        <h1><span class="anchor-ref" id="{{.ID}}"></span>{{.Title}}</h1>
       {{ end }}
       {{.Content}}
     </div>

--- a/static/js/fts_exec.js
+++ b/static/js/fts_exec.js
@@ -56,10 +56,13 @@ const debounce = (n,t,u) => {var e;return function(){var i=this,o=arguments,a=u&
                 .trim();
 
             const allIndexes = terms
-                .map(t => containerText.includes(t) ? { 
-                    start: Math.max(0, idx - 100),
-                    end: idx + 100
-                } : false)
+                .map(t => {
+                  const idx = containerText.indexOf(t);
+                  if (idx === -1) {
+                    return false;
+                  }
+                  return { start: Math.max(0, idx - 100), end: idx + 100 };
+                })
                 .filter(Boolean);
 
             if (allIndexes.length === 0) {


### PR DESCRIPTION
This updates how anchoring is done, which fixes `fts_exec`, bringing search back.
This also reverts a change in `fts_exec` introduced by #8, which broke the search feature.