### PR TITLE
fix(img): add responsiveness with restriction to content size

### DIFF
--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -105,6 +105,11 @@ h3, h4, h5, h6 {
     justify-content: space-between;
 }
 
+section img {
+    width: 100%;
+    height: auto;
+}
+
 .logo {
     g[stroke='#fff'] {
         stroke: var(--logo-color);


### PR DESCRIPTION
**Description:**
Add responsiveness to images inside `<section>` elements, enclosing the `<img>` into its section size.
Possibly fix for #17 

**Screenshots:**
| Mobile | PC |
| ------- | -- |
| <img src="https://user-images.githubusercontent.com/28108272/119242163-1df0a080-bb32-11eb-8754-dfd6b6b4181f.png" width="320" /> |  <img src="https://user-images.githubusercontent.com/28108272/119242185-3d87c900-bb32-11eb-845e-b22e74b985c4.png" width="640" /> |

**Videos:**
https://user-images.githubusercontent.com/28108272/119242138-fe597800-bb31-11eb-9b76-5f785cd9f47e.mp4
https://user-images.githubusercontent.com/28108272/119242142-05808600-bb32-11eb-8147-29fa7a26159d.mp4

